### PR TITLE
ensure sources are imported when coverage is enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raegen/vite-plugin-vitest-cache",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Run Vitest with test result caching.",
   "repository": {
     "type": "git",

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,6 +1,6 @@
 import { File, Task, updateTask, VitestRunner } from '@vitest/runner';
 import { VitestTestRunner } from 'vitest/runners';
-import { TaskCache, CacheEntry } from './cache.js';
+import { CacheEntry, TaskCache } from './cache.js';
 import { format } from './util.js';
 import { inject } from 'vitest';
 import { CacheOptions } from './options.js';
@@ -10,13 +10,20 @@ declare module 'vitest' {
     'v-cache:data': {
       [key: string]: CacheEntry;
     };
-    'v-cache:config': Omit<CacheOptions, 'strategy'>
+    'v-cache:config': Omit<CacheOptions, 'strategy'>;
   }
 }
 
 class CachedRunner extends VitestTestRunner implements VitestRunner {
   private cache = new TaskCache<File>(inject('v-cache:data'));
   private options = inject('v-cache:config');
+
+  async provideCoverage(path: string) {
+    try {
+      await super.importFile(path, 'collect');
+    } catch (e) {
+    }
+  }
 
   shouldCache(task: Task): boolean {
     return this.options.states.includes(task.result.state);
@@ -38,6 +45,10 @@ class CachedRunner extends VitestTestRunner implements VitestRunner {
         }
         updateTask(cached, this);
         restored.push(cached);
+      }
+      if (this.config.coverage.enabled) {
+        // coverage relies on runner imported sources
+        await this.provideCoverage(test);
       }
     }
     this.onCollected?.(restored);


### PR DESCRIPTION
Fixes https://github.com/raegen/vite-plugin-vitest-cache/issues/16